### PR TITLE
fix(configure): Prevent pulling in unnecessary vars

### DIFF
--- a/configure
+++ b/configure
@@ -423,7 +423,7 @@ genConfigMake() {
   cfgwrite ""
 
   cfgwrite "# GNUstep environment variables:";
-  for i in `env | grep GNUSTEP_ | sort`; do
+  for i in `env | grep ^GNUSTEP_ | sort`; do
     MAKE_ASSI="`echo $i | sed s/=/:=/`"
     cfgwrite "${MAKE_ASSI}";
   done


### PR DESCRIPTION
Things like `NIX_GNUSTEP_BASE` would get pulled in without this patch which causes the build to fail.