### PR TITLE
fix(smtp): Fix -Wformat

### DIFF
--- a/sope-mime/NGMail/NGSmtpClient.m
+++ b/sope-mime/NGMail/NGSmtpClient.m
@@ -727,7 +727,8 @@
     {
       NSLog(@"SMTP(MAIL FROM) error: %@", [reply text]);
       [NSException raise: @"SMTPException"
-                  format: [reply text]];
+                  format: @"%@",
+                  [reply text]];
     }
   return NO;
 }
@@ -752,7 +753,8 @@
     {
       NSLog(@"SMTP(RCPT TO) error: %@", [reply text]);
       [NSException raise: @"SMTPException"
-                  format: [reply text]];
+                  format: @"%@",
+                  [reply text]];
     }
   return NO;
 }
@@ -846,7 +848,8 @@
     {
       NSLog(@"SMTP(DATA) error: %@", [reply text]);
       [NSException raise: @"SMTPException"
-                  format: [reply text]];
+                  format: @"%@",
+                  [reply text]];
     }
   return NO;
 }


### PR DESCRIPTION
Rather than treating the SMTP output as a format string, explicitly specify a format string. This is more secure and allows building with `-Wformat -Wformat-security -Werror=format-security`