### PR TITLE
support for gnustep base >= 1.29.0

### DIFF
--- a/sope-mime/NGMime/NGMimeType.m
+++ b/sope-mime/NGMime/NGMimeType.m
@@ -125,7 +125,8 @@ static Class NSStringClass  = Nil;
     encoding = NSKoreanEUCStringEncoding;
   }
   else if ([charset isEqualToString:@"big5"]) {
-#if ((GNUSTEP_BASE_MAJOR_VERSION >= 1) && (GNUSTEP_BASE_MINOR_VERSION >= 19) && (GNUSTEP_BASE_SUBMINOR_VERSION >= 0))
+#define C_GNUSTEP_VERSION (GNUSTEP_BASE_MAJOR_VERSION * 1000000) + (GNUSTEP_BASE_MINOR_VERSION * 1000) + GNUSTEP_BASE_SUBMINOR_VERSION
+#if C_GNUSTEP_VERSION >= 1029000
     encoding = NSBig5StringEncoding;
 #else
     encoding = NSBIG5StringEncoding;
@@ -135,7 +136,7 @@ static Class NSStringClass  = Nil;
     encoding = NSISO2022JPStringEncoding;
   }
   else if ([charset isEqualToString:@"gb2312"]) {
-#if ((GNUSTEP_BASE_MAJOR_VERSION >= 1) && (GNUSTEP_BASE_MINOR_VERSION >= 19) && (GNUSTEP_BASE_SUBMINOR_VERSION >= 0))
+#if C_GNUSTEP_VERSION >= 1029000
     encoding = NSHZ_GB_2312StringEncoding;
 #else
     encoding = NSGB2312StringEncoding;

--- a/sope-mime/NGMime/NGMimeType.m
+++ b/sope-mime/NGMime/NGMimeType.m
@@ -125,13 +125,21 @@ static Class NSStringClass  = Nil;
     encoding = NSKoreanEUCStringEncoding;
   }
   else if ([charset isEqualToString:@"big5"]) {
+#if ((GNUSTEP_BASE_MAJOR_VERSION >= 1) && (GNUSTEP_BASE_MINOR_VERSION >= 19) && (GNUSTEP_BASE_SUBMINOR_VERSION >= 0))
+    encoding = NSBig5StringEncoding;
+#else
     encoding = NSBIG5StringEncoding;
+#endif
   }
   else if ([charset isEqualToString:@"iso-2022-jp"]) {
     encoding = NSISO2022JPStringEncoding;
   }
   else if ([charset isEqualToString:@"gb2312"]) {
+#if ((GNUSTEP_BASE_MAJOR_VERSION >= 1) && (GNUSTEP_BASE_MINOR_VERSION >= 19) && (GNUSTEP_BASE_SUBMINOR_VERSION >= 0))
+    encoding = NSHZ_GB_2312StringEncoding;
+#else
     encoding = NSGB2312StringEncoding;
+#endif
   }
   else if ([charset isEqualToString:@"koi8-r"]) {
     encoding = NSKOI8RStringEncoding;


### PR DESCRIPTION
some enum constants in gnustep base libs have changed with 1.29.0, which breaks compatibility with sope.
changing commit is: https://github.com/gnustep/libs-base/commit/fe2f41c7f19f19bf8b5100a2124e815d92d784d1

only two enum constants in NGMimeType.m are affected, both of which under a section commented with "some unsupported, but known encoding". from gnustep base 1.29.0 on there are multiple enum constants for GB2312 encoding. after some research i decided to go for NSHZ_GB_2312StringEncoding, because it references the 7-bit HZ-encoding used in mailing.