### PR TITLE
Fix XML namespace for DAV error element

### DIFF
--- a/sope-appserver/NGObjWeb/SoObjects/SoDefaultRenderer.m
+++ b/sope-appserver/NGObjWeb/SoObjects/SoDefaultRenderer.m
@@ -126,7 +126,7 @@ static int debugOn = 0;
     {
       [r setHeader:@"application/xml; charset=\"utf-8\"" forKey:@"content-type"];
       [r appendContentString: @"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
-                        @"<D:error xmlns:D=\"DAV\">"];
+                        @"<D:error xmlns:D=\"DAV:\">"];
       [r appendContentString: [[_ex reason] stringByEscapingXMLString]];
       [r appendContentString: @"</D:error>"];
     }


### PR DESCRIPTION
Currently DAV errors have incorrect namespace of _error_ tag "DAV" but it should "DAV:" with a colon.
Example of error I get:
HTTP/1.1 403 Forbidden
```
content-length: 93
content-type: application/xml; charset="utf-8"

<?xml version="1.0" encoding="utf-8"?>
<D:error xmlns:D="DAV">sequences don't match</D:error>
```

RFC https://datatracker.ietf.org/doc/html/rfc4918#section-14 in section 14 says that "All elements defined here are in the "DAV:" namespace."
Section 14.5 describes the error element.
All examples of using _error_ element are desribed as
```xml
  <D:error xmlns:D="DAV:">
   ...
  </D:error>
```
This PR changes the namespace from DAV to DAV:

SOGo BTS: https://bugs.sogo.nu/view.php?id=5964