### PR TITLE
Update Languages.plist: NGObjWeb: map "tr"/"tr-tr" to TurkishTurkey (SOGo ships no Turkish.lproj)

### DIFF
--- a/sope-appserver/NGObjWeb/Languages.plist
+++ b/sope-appserver/NGObjWeb/Languages.plist
@@ -157,7 +157,8 @@
   "tl"    = "Tagalog";
   "tn"    = "Setswana";
   "to"    = "Tonga";
-  "tr"    = "Turkish";
+  "tr"    = "TurkishTurkey";
+  "tr-tr" = "TurkishTurkey";
   "ts"    = "Tsonga";
   "tt"    = "Tatar";
   "tw"    = "Twi";


### PR DESCRIPTION
## Problem

SOGo's Turkish translation is shipped only as `TurkishTurkey.lproj` (all 11 UI bundles in Alinto/sogo master; there is no `Turkish.lproj`). NGObjWeb's browser-language table `sope-appserver/NGObjWeb/Languages.plist` still maps the bare code to the old name:

    "tr"    = "Turkish";

As a result a browser that sends `Accept-Language: tr-TR,tr` never reaches the Turkish translation: WOResourceManager looks for `Turkish.lproj`, logs

sogod [pid]: [ERROR] [we-rm] did not find locale for language: Turkish and SOGo falls back to English (login page, and the whole UI for every user who has not saved a language preference yet), regardless of `SOGoLanguage = TurkishTurkey` in sogo.conf.

## Reproduction (SOGo 5.12.9 + SOPE 4.9, OpenBSD 7.9 packages)

curl -sk -H 'Accept-Language: tr-TR,tr;q=0.9,en;q=0.5' https://mail.example.com/SOGo/ | grep -o '<html[^>]*lang="[^"]*"'
    -> lang="en"          (expected: Turkish)
    curl -sk -H 'Accept-Language: de-DE,de;q=0.9' ...  -> lang="de"   (German works: "de" = "German" and German.lproj exists)

    ls /usr/local/lib/GNUstep/SOGo/MainUI.SOGo/Resources/ | grep -i turk
    TurkishTurkey.lproj   (no Turkish.lproj)

## Fix

Point the mapping at the bundle that actually exists, exactly like the existing entries for Spanish (`"es" = "SpanishSpain"`; SOGo ships `SpanishSpain.lproj`, no `Spanish.lproj`), and add the regional key browsers send:

    "tr"    = "TurkishTurkey";
    "tr-tr" = "TurkishTurkey";

## Verification

With the one-line change applied to the installed plist and sogod restarted:

    Accept-Language: tr-TR,tr;q=0.9,en;q=0.5  -> <html lang="tr-TR">
    Accept-Language: en-US,en;q=0.9           -> lang="en"   (unchanged)
    Accept-Language: de-DE,de;q=0.9           -> lang="de"   (unchanged)
    sogo.log: no further "did not find locale for language: Turkish" entries

Verified on three OpenBSD 7.9 hosts (SOGo 5.12.9, sope-4.9 packages). Users who have explicitly saved another language in Preferences are not affected; only the browser-language detection changes.